### PR TITLE
Split app listing and website generation into two separate steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: git checkout -b gh-pages
       - run: pip3 install -r requirements.txt
-      - run: python3 main.py
+      - run: python3 generate_json.py
         env:
           GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+      - run: python3 generate_site_from_json.py
       - run: 'echo "droidtoberfest.sylviavanos.nl" > docs/CNAME'
       - run: git config user.name github-actions
       - run: git config user.email github-actions@github.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-docs
+docs/*
+!docs/.gitkeep

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Goes through all apps on [IzzyOnDroid](https://apt.izzysoft.de/fdroid/) and [F-D
 
 It reads the index-v2 of the repositories and then checks each repository on GitHub and GitLab. It then generates a .html page which is pushed to the gh-pages branch, so GitHub hosts it.
 
+The generation happens in two steps.
+
+1. `generate_json.py` generates a JSON file containing all app data and stores it in `docs/apps.json`
+2. `generate_site_from_json.py` reads `docs/app.json` and generates a webpage with that info
+
 ## Contributing
 
-If you want to contribute to the design, the easiest way is probably to just go to the gh-pages branch, try out your changes in the docs directory and if they look good apply them to the relevant files in the templates or static directory.
+Contributing is easiest if you have Python installed (and required for code contributions). You can install all dependencies in a venv with `pip3 install -r requirements.txt`.
 
-If you want to improve the Python script or want to test your changes more thoroughly, you'll want to make sure you have Python 3 installed, install the dependencies (in a venv) with `pip3 install -r requirements.txt` and run the script with `python3 main.py`.
+If you want to contribute to the UI, you can use the `gh-pages` branch and run `generate_site_from_json.py` whenever you make changes to the template, it puts the generated website into the `docs` directory.
 
-Be aware that building the complete list of apps [easily takes over an hour](https://github.com/TheLastProject/Droidtoberfest/actions/workflows/build.yml) even when using a [permission-less fine-grained GitHub Personal Access Token](https://github.com/settings/tokens?type=beta) in the `GITHUB_TOKEN` environment variable. It is therefore best to set the `DEBUG_APP_LIMIT` environment variable to a low value for testing purposes like this: `GITHUB_TOKEN=your_github_token DEBUG_APP_LIMIT=5 python3 main.py`.
+Be aware that building the complete list of apps [easily takes over an hour](https://github.com/TheLastProject/Droidtoberfest/actions/workflows/build.yml) even when using a [permission-less fine-grained GitHub Personal Access Token](https://github.com/settings/tokens?type=beta) in the `GITHUB_TOKEN` environment variable. It is therefore best when working on `generate_json.py` to set the `DEBUG_APP_LIMIT` environment variable to a low value for testing purposes like this: `GITHUB_TOKEN=your_github_token DEBUG_APP_LIMIT=5 python3 generate_json.py`.
 
 ## License
 CC0 1.0 Universal

--- a/generate_site_from_json.py
+++ b/generate_site_from_json.py
@@ -1,0 +1,18 @@
+import json
+import shutil
+
+from jinja2 import Environment, FileSystemLoader
+
+if __name__ == "__main__":
+    # Load current config
+    with open('docs/apps.json') as app_data:
+        apps = json.load(app_data)
+    
+    # Copy CSS
+    shutil.copy('static/style.css', 'docs')
+    
+    # Render template
+    template = Environment(loader=FileSystemLoader('templates')).get_template('index.html.j2')
+    with open('docs/index.html', 'w+') as f:
+        html = template.render(apps=apps)
+        f.write(html)


### PR DESCRIPTION
This allows regenerating the website after making template changes without having to regenerate the whole app listing

Fixes #7 

This doesn't implement anything clever to make GitHub Actions skip generating the app listing but updating that more often than on the schedule isn't a huge deal anyway